### PR TITLE
Prepare for Uint8List SDK breaking change

### DIFF
--- a/lib/zakah.dart
+++ b/lib/zakah.dart
@@ -67,7 +67,7 @@ class Mpesa {
     HttpClientResponse res = await req.close();
 
     // u should use `await res.drain()` if u aren't reading the body
-    await res.transform(utf8.decoder).forEach((bodyString) {
+    await utf8.decoder.bind(res).forEach((bodyString) {
       dynamic jsondecodeBody = jsonDecode(bodyString);
       access_token = jsondecodeBody["access_token"].toString();
       access_expires_at =
@@ -109,7 +109,7 @@ class Mpesa {
     req.write(jsonEncode(b2cPayload)); // write is non-blocking
     HttpClientResponse res = await req.close();
 
-    await res.transform(utf8.decoder).forEach((bodyString) {
+    await utf8.decoder.bind(res).forEach((bodyString) {
       dynamic jsondecodeBody = jsonDecode(bodyString);
 
       if (res.statusCode == 200) {


### PR DESCRIPTION
A recent change to the Dart SDK updated `HttpClientResponse`
to implement `Stream<Uint8List>` rather than implementing
`Stream<List<int>>`.

This forwards-compatible change updates calls to
`Stream.transform(StreamTransformer)` to instead call the
functionally equivalent `StreamTransformer.bind(Stream)`
API, which puts the stream in a covariant position and
thus causes the SDK change to be non-breaking.

https://github.com/dart-lang/sdk/issues/36900
